### PR TITLE
Correct "preceeding" to "preceding"

### DIFF
--- a/kimeds-ontology.owl
+++ b/kimeds-ontology.owl
@@ -182,9 +182,9 @@ _:ekfz schema:name "EKFZ, TU Dresden" .
             rdfs:range :Risk .
 
 
-###  http://semanticweb.org/kettmann/ontologies/2023/5/kimeds-ontology#hasPreceedingEvent
-:hasPreceedingEvent rdf:type owl:ObjectProperty ;
-                    rdfs:label "has preceeding event" ;
+###  http://semanticweb.org/kettmann/ontologies/2023/5/kimeds-ontology#hasPrecedingEvent
+:hasPrecedingEvent rdf:type owl:ObjectProperty ;
+                    rdfs:label "has preceding event" ;
                     rdfs:subPropertyOf owl:topObjectProperty ;
                     rdfs:domain :Event ;
                     rdfs:range :Event .

--- a/kimeds.shacl
+++ b/kimeds.shacl
@@ -71,7 +71,7 @@ kimeds:EventShape
   a sh:NodeShape ;
   sh:targetClass kimeds:Event ;
   sh:property [ 
-    sh:path kimeds:hasPreceedingEvent;
+    sh:path kimeds:hasPrecedingEvent;
   ]
 .
 


### PR DESCRIPTION
closes #17 